### PR TITLE
Allow relative log/autoload paths

### DIFF
--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -525,6 +525,10 @@ class Fresque
                 . $this->runtime['Redis']['host'] . ':' . $this->runtime['Redis']['port'];
         }
         
+        // Make log absolute to cwd
+        if (substr($this->runtime['Fresque']['log'], 0, 2) == '.' . DS) {
+            $this->runtime['Fresque']['log'] = getcwd() . DS . $this->runtime['Fresque']['log'];
+        }
         
         $logPath = pathinfo($this->runtime['Fresque']['log'], PATHINFO_DIRNAME);
         if (!is_dir($logPath)) {
@@ -556,6 +560,11 @@ class Fresque
             $results['PHPResque library'] = 'Unable to find PHPResque library';
         }
         
+        
+        // Make autoloader absolute to cwd
+        if (substr($this->runtime['Fresque']['include'], 0, 2) == '.' . DS) {
+            $this->runtime['Fresque']['include'] = getcwd() . DS . $this->runtime['Fresque']['include'];
+        }
         
         if (!file_exists($this->runtime['Fresque']['include'])) {
             $results['Application autoloader'] = 'Your application autoloader file was not found';


### PR DESCRIPTION
This PR allows you to give relative paths in your fresque.ini:

```
log     = ./app/logs/fresque.log
include = ./vendor/autoload.php
```

It will detect the ./ and then automatically applies the current working directory of where the commands gets executed to make an absolute path. The absolute paths are necessary for PHP-Resque to work properly.
