### PR TITLE
2 Bugs found with latest release

### DIFF
--- a/fresque.ini
+++ b/fresque.ini
@@ -35,7 +35,7 @@ namespace = 'resque'
 ; Fresque is shipped with a copy of the php-resque
 ; library, but it you have already included one in your
 ; application, and wish to use it, put in its path
-lib 	= ./vendor/chrisboulton/php-resque
+lib 	= ./vendor/kamisama/php-resque-ex
 
 ; Absolute path to the entry point of you application
 ; In order to execute your jobs, php-resque have to know

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -453,7 +453,7 @@ class Fresque
             $success = false;
             $attempt = 7;
             while ($attempt-- > 0) {
-                for ($i = 0; $i < 3; $i++) {
+                for ($x = 0; $x < 3; $x++) {
                     $this->output->outputText(".", 0);
                     usleep(self::$checkStartedWorkerBufferTime);
                 }


### PR DESCRIPTION
I recently upgraded from v0.1 to the latest 1.2 code and found a few bugs when trying to get my workers back up and running.

Fixes a bug with starting workers: There was a collision between for() count variables, you are using $i in 2 nested for() loops, causing workers to endlessly spawn in some configurations.

Fixes a default ini setting pointing to a replaced composer dependency: The default fresque.ini file was still pointing to the default php-resque dependency, not your expanded php-resque-ex dependency

This pull request fixes both of these bugs.
