### PR TITLE
fixing 'load' command - now runned workers serve their own queue instead...

### DIFF
--- a/fresque.ini
+++ b/fresque.ini
@@ -130,7 +130,8 @@ target =
 ; QUEUENAME[PROPERTY] = VALUE
 ;activity[workers] = 2
 ;
-; PROPERTY can be any of the key defined in [Default] (above)
+; PROPERTY can be any of the key defined in [Default], [Redis],
+; [Fresque] or [Log] sections (above)
 
 ;
 ; If you don't set the other properties (interval, user etc ...),

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -1037,26 +1037,6 @@ class Fresque
         $this->runtime = parse_ini_file($this->config, true);
 
         $settings = array(
-            $this->runtime['Redis']['host'] => 'host',
-            $this->runtime['Redis']['port'] => 'port',
-            $this->runtime['Log']['filename'] => 'log',
-            $this->runtime['Log']['handler'] => 'loghandler',
-            $this->runtime['Log']['target'] => 'handlertarget',
-            $this->runtime['Fresque']['lib'] => 'lib',
-            $this->runtime['Fresque']['include'] => 'autoloader',
-            $this->runtime['Default']['user'] => 'user',
-            $this->runtime['Default']['queue'] => 'queue',
-            $this->runtime['Default']['workers'] => 'workers',
-            $this->runtime['Default']['interval'] => 'interval'
-        );
-
-        foreach ($settings as $runtime => $option) {
-            if (isset($options[$option])) {
-                $this->runtime['Default'][$option] = $options[$option];
-            }
-        }
-
-        $settings = array(
             'Redis' => array(
                 'host',
                 'port',


### PR DESCRIPTION
... of default

If several queues are defined in [Queues] section of config file, it used to run all workers with configuration taken from [Default] section. Now it respects what is specified in [Queues] per each queue.
