### PR TITLE
Fix kill when user differs to process owner

### DIFF
--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -1448,7 +1448,7 @@ class Fresque
     protected function kill($signal, $pid)
     {
         $output = array();
-        $message = exec(sprintf('/bin/kill -%s %s 2>&1', $signal, $pid), $output, $code);
+        $message = exec(sprintf(($this->runtime['Default']['user'] !== $this->getProcessOwner() ? ('sudo -u '. escapeshellarg($this->runtime['Default']['user'])) . ' ' : "") . '/bin/kill -%s %s 2>&1', $signal, $pid), $output, $code);
         return array('code' => $code, 'message' => $message);
     }
 


### PR DESCRIPTION
When running Fresque on my Vagrant box with the user set to `www-data` but running the commands as `vagrant`, I noticed that the `stop` command did not work.

It didn't report an error, but it did not output the green "Done" text next to each stopped worker. The output looked something like:

```
----------------
Stopping workers
----------------
Workers list
  1) vagrant:8048:dispatched_orders, started 1 day and 2 hours ago
  2) vagrant:8039:new_orders, started 1 day and 2 hours ago
all) Stop all workers

Worker to stop: all
stopping 8048 ... 
stopping 8039 ... 

```

I copied some code for running the command as another user from the `start` method. It might want some abstraction to avoid the repetition, but I wasn't sure what other commands might be affected.
