### PR TITLE
Add new options for stop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ Scheduler worker is disabled by default, enable it in the configuration file, in
 To stop workers. Will wait for all jobs to finish, then stop the worker. If more than one worker is running, a list of workers will be displayed, to choose the worker to stop.
 
 > `-f` or `--force` : Stop worker immediately, without waiting for the current job to finish processing. This will fail the current job.
+
 > `-w` or `--all` : Stop all workers at once, skipping the worker menu.
+
 > `-q` or `--queue` : Stop all workers attributed to the specified queue name.
-> `-o` or `--count` : An additional which can be specified along with the `--queue` option to stop fix number of workers from the queue.
+
+> `-o` or `--count` : An additional optional which can be specified along with the `--queue` option to stop a fixed number of workers from the queue.
 
 * **pause**
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ To stop workers. Will wait for all jobs to finish, then stop the worker. If more
 
 > `-f` or `--force` : Stop worker immediately, without waiting for the current job to finish processing. This will fail the current job.
 > `-w` or `--all` : Stop all workers at once, skipping the worker menu.
+> `-q` or `--queue` : Stop all workers attributed to the specified queue name.
+> `-o` or `--count` : An additional which can be specified along with the `--queue` option to stop fix number of workers from the queue.
 
 * **pause**
 
@@ -259,11 +261,15 @@ It should output something like that
 		 - Processed Jobs : 0
 		 - Failed Jobs    : 0
 
+Let's stop all workers from the *default* queue and one from the *activity* queue
+
+	$ fresque stop -c /path/to/my-config.ini -q default
+	$ fresque stop -c /path/to/my-config.ini -q activity -o 1
 
 Remember that you can use the global options (-s, -p etc …) with any command
 
 	$ fresque stop -c /path/to/my-config.ini -s 192.168.1.26
-
+	
 Let's enqueue a job to the *activity* queue
 
 	$ fresque enqueue activity PageVisit "5,/index.php,158745693"

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -702,6 +702,10 @@ class Fresque
                         $workerIndex = array_slice($workerIndex, 0, $count);
                     }
                     
+                    if (empty($workerIndex)) {
+                        $this->output->outputLine($options->noWorkersMessage, 'failure');
+                    }
+                                        
                 } else {
                     $menuItems = array();
                     foreach ($options->workers as $i => $worker) {

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -691,10 +691,10 @@ class Fresque
             $workerIndex = array();
             if (!$all && $options->getWorkersCount() > 1) {
                 if ($workerQueueName) {
-                    foreach ($options->workers as $index => $worker) {
+                    foreach ($options->workers as $i => $worker) {
                         list($hostname, $pid, $queue) = explode(':', (string)$worker);
                         if ($queue == $workerQueueName) {
-                            $workerIndex[] = $index;
+                            $workerIndex[] = $i;
                         }
                     }
                     
@@ -703,10 +703,9 @@ class Fresque
                     }
                     
                 } else {
-                    $i = 1;
                     $menuItems = array();
-                    foreach ($options->workers as $worker) {
-                        $menuItems[$i++] = $listFormatter($worker);
+                    foreach ($options->workers as $i => $worker) {
+                        $menuItems[$i] = $listFormatter($worker);
                     }
                     
                     $menuItems['all'] = $options->allOption;
@@ -729,7 +728,7 @@ class Fresque
             }
 
             foreach ($workerIndex as $index) {
-                $worker = $options->workers[$index - 1];
+                $worker = $options->workers[$index];
 
                 list($hostname, $pid, $queue) = explode(':', (string)$worker);
 

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -557,7 +557,7 @@ class Fresque
         $this->debug('Searching for active workers');
         $options = new SendSignalCommandOptions();
         $options->title = 'Stopping workers';
-        $options->noWorkersMessage = 'There is no workers to stop';
+        $options->noWorkersMessage = 'There are no workers to stop';
         $options->allOption = 'Stop all workers';
         $options->selectMessage = 'Worker to stop';
         $options->actionMessage = 'stopping';
@@ -595,7 +595,7 @@ class Fresque
         $this->debug('Searching for active workers');
         $options = new SendSignalCommandOptions();
         $options->title = 'Pausing workers';
-        $options->noWorkersMessage = 'There is no workers to pause';
+        $options->noWorkersMessage = 'There are no workers to pause';
         $options->allOption = 'Pause all workers';
         $options->selectMessage = 'Worker to pause';
         $options->actionMessage = 'pausing';
@@ -621,7 +621,7 @@ class Fresque
         $this->debug('Searching for paused workers');
         $options = new SendSignalCommandOptions();
         $options->title = 'Resuming workers';
-        $options->noWorkersMessage = 'There is no paused workers to resume';
+        $options->noWorkersMessage = 'There are no paused workers to resume';
         $options->allOption = 'Resume all workers';
         $options->selectMessage = 'Worker to resume';
         $options->actionMessage = 'resuming';

--- a/tests/FresqueTest.php
+++ b/tests/FresqueTest.php
@@ -414,8 +414,8 @@ class FresqueTest extends \PHPUnit_Framework_TestCase
                     'options' => array('u' => 'username', 'q' => 'queue name',
                             'i' => 'num', 'n' => 'num', 'l' => 'path', 'v', 'g')),
             'stop' => array(
-                    'help' => 'Shutdown all workers',
-                    'options' => array('f', 'w', 'g'))
+                    'help' => 'Stop workers',
+                    'options' => array('f', 'w', 'g', 'q', 'o'))
         );
 
         $this->output->expects($this->at(2))->method('outputLine')->with($this->stringContains('Available commands'));
@@ -519,7 +519,9 @@ class FresqueTest extends \PHPUnit_Framework_TestCase
 
         $this->input->expects($this->at(0))->method('getOption')->with($this->equalTo('force'))->will($this->returnValue($option));
         $this->input->expects($this->at(1))->method('getOption')->with($this->equalTo('all'))->will($this->returnValue($option));
-        $this->input->expects($this->exactly(2))->method('getOption');
+        $this->input->expects($this->at(2))->method('getOption')->with($this->equalTo('queue'))->will($this->returnValue($option));
+        $this->input->expects($this->at(3))->method('getOption')->with($this->equalTo('count'))->will($this->returnValue($option));
+        $this->input->expects($this->exactly(4))->method('getOption');
 
         $this->shell->expects($this->once())->method('outputTitle')->with($this->stringContains('testing workers'));
         $this->output->expects($this->at(0))->method('outputText')->with($this->stringContains('testing 100 ...'));
@@ -553,7 +555,9 @@ class FresqueTest extends \PHPUnit_Framework_TestCase
 
         $this->input->expects($this->at(0))->method('getOption')->with($this->equalTo('force'))->will($this->returnValue($option));
         $this->input->expects($this->at(1))->method('getOption')->with($this->equalTo('all'))->will($this->returnValue($option));
-        $this->input->expects($this->exactly(2))->method('getOption');
+        $this->input->expects($this->at(2))->method('getOption')->with($this->equalTo('queue'))->will($this->returnValue($option));
+        $this->input->expects($this->at(3))->method('getOption')->with($this->equalTo('count'))->will($this->returnValue($option));
+        $this->input->expects($this->exactly(4))->method('getOption');
 
         $this->shell->expects($this->once())->method('outputTitle')->with($this->stringContains('testing workers'));
         $this->output->expects($this->at(0))->method('outputText')->with($this->stringContains('testing 100 ...'));
@@ -587,7 +591,9 @@ class FresqueTest extends \PHPUnit_Framework_TestCase
 
         $this->input->expects($this->at(0))->method('getOption')->with($this->equalTo('force'))->will($this->returnValue($option));
         $this->input->expects($this->at(1))->method('getOption')->with($this->equalTo('all'))->will($this->returnValue($option));
-        $this->input->expects($this->exactly(2))->method('getOption');
+        $this->input->expects($this->at(2))->method('getOption')->with($this->equalTo('queue'))->will($this->returnValue($option));
+        $this->input->expects($this->at(3))->method('getOption')->with($this->equalTo('count'))->will($this->returnValue($option));
+        $this->input->expects($this->exactly(4))->method('getOption');
 
         $this->shell->expects($this->once())->method('outputTitle')->with($this->stringContains('testing workers'));
         $this->output->expects($this->at(0))->method('outputText')->with($this->stringContains('testing 101 ...'));
@@ -651,7 +657,7 @@ class FresqueTest extends \PHPUnit_Framework_TestCase
 
         $shell->stop();
     }
-
+    
     /**
      * Pause will send the USR2 signal and the active workers list to sendSignal()
      *


### PR DESCRIPTION
Hey,

As promised, here is the code for the feature we discussed a week ago.

Two new commands have been added, `--queue` (`-q`) and `--count` (`-o`). If only `-q` is specified all workers attributed to the queue will be stopped; if the `-o` option is specified then you can stop a fixed number of workers for the queue.

I have updated the README and the unit tests; also fixed some minor grammar errors. I haven't written any new unit tests yet since they look quite cryptic but you can advice me in this regards.

I have been using this in my production environment for almost a week and it is solid so far.

Regards
