### PR TITLE
Pass existing environment variables to each worker

### DIFF
--- a/fresque.ini
+++ b/fresque.ini
@@ -172,4 +172,16 @@ log = /path/to/resque-scheduler.log
 ; handler = RotatingFile
 ; target =  /path/to/resque-scheduler.log
 
+[Env]
+
+; Environment variables that you want to pass to the workers
+; Useful for example if you don't keep the database credentials or API keys in your source code
+
+; Passing a key only will search for its value from the getenv() function
+; MYSQL_USER =
+; MYSQL_PASSWORD =
+
+; Passing a key and a value will set the env variable to this value
+; APP_ENV = dev
+
 ; That's all folks !

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -471,8 +471,13 @@ class Fresque
 
             $libraryPath = rtrim($libraryPath, '/');
 
+            // build environment variables string to be passed to the worker
             $env_vars = "";
-            foreach($_ENV as $env_name => $env_value) {
+            foreach($this->runtime['Env'] as $env_name => $env_value) {
+                // if only the name is supplied, we get the value from environment
+                if (strlen($env_value) == 0) {
+                    $env_value = getenv($env_name);
+                }
                 $env_vars .= $env_name . '=' . escapeshellarg($env_value) . " \\\n";
             }
 
@@ -1172,7 +1177,8 @@ class Fresque
                 'interval',
                 'handler',
                 'target'
-            )
+            ),
+            'Env' => array()
         );
 
         foreach ($settings as $scope => $param_names) {

--- a/lib/Fresque.php
+++ b/lib/Fresque.php
@@ -471,9 +471,15 @@ class Fresque
 
             $libraryPath = rtrim($libraryPath, '/');
 
+            $env_vars = "";
+            foreach($_ENV as $env_name => $env_value) {
+                $env_vars .= $env_name . '=' . escapeshellarg($env_value) . " \\\n";
+            }
+
             $cmd = 'nohup ' . ($this->runtime['Default']['user'] !== $this->getProcessOwner() ? ('sudo -u '. escapeshellarg($this->runtime['Default']['user'])) : "") . " \\\n".
             'bash -c "cd ' .
             escapeshellarg($libraryPath) . '; ' . " \\\n".
+            $env_vars .
             (($this->runtime['Default']['verbose']) ? 'VVERBOSE' : 'VERBOSE') . '=true ' . " \\\n".
             'QUEUE=' . escapeshellarg($this->runtime['Default']['queue']) . " \\\n".
             'PIDFILE=' . escapeshellarg($pidFile) . " \\\n".


### PR DESCRIPTION
Environment variables that exist in the Fresque scripts were not passed to the workers (the call to passthru here https://github.com/kamisama/Fresque/blob/master/lib/Fresque.php#L1435 doesn't inherit from the env vars of the current script, and it doesn't load /etc/environment or other files where environment variables would be set).

This patch passes the environment variables to each worker. It is useful for me because I have an system wide environment variable "APP_ENV" that tells my PHP app about what environment is run (dev, prod, staging...) with something like this:

```php
define('ENV', getenv("APP_ENV"));
```
Useful also if you put your credentials, API keys, things like that in system wide environment variables, and not as PHP constants in your bootstrap script.

```php
define('MYSQL_HOST', getenv("APP_MYSQL_HOST"));
define('MYSQL_USER', getenv("APP_MYSQL_USER"));
define('MYSQL_PASSWORD', getenv("APP_MYSQL_PASSWORD"));
```

I appended the environment variables first, so that it will not override the Fresque vars, in case their name is also used by Fresque.

What do you think?